### PR TITLE
Helper functions to replace standard browser popups

### DIFF
--- a/lib/jquery.dialog2.js
+++ b/lib/jquery.dialog2.js
@@ -512,4 +512,93 @@
             }
         });
     };
+    
+    $.dialog2 = {
+        alert: function(message, callback, options) {
+            var dialogOptions = {
+                title: 'Alert',
+                buttonLabel: 'OK'
+            };
+            if (options) {
+                $.extend(dialogOptions, options);
+            }
+            $.dialog2.open(dialogOptions.title, message, [
+                {
+                    label: dialogOptions.buttonLabel,
+                    classes: 'primary close-dialog',
+                    callback: callback
+                }
+            ]);
+        },
+
+        confirm: function(message, callbackYes, callbackNo, options) {
+            var dialogOptions = {
+                title: 'Confirmation',
+                buttonLabelYes: 'Yes',
+                buttonLabelNo: 'No'
+            };
+            if (options) {
+                $.extend(dialogOptions, options);
+            }
+            $.dialog2.open(dialogOptions.title, message, [
+                {
+                    label: dialogOptions.buttonLabelNo,
+                    classes: 'danger close-dialog',
+                    callback: callbackNo
+                },
+                {
+                    label: dialogOptions.buttonLabelYes,
+                    classes: 'primary close-dialog',
+                    callback: callbackYes
+                }
+            ]);
+        },
+
+        prompt: function(message, defaultValue, callbackOk, callbackCancel, options) {
+            var dialogOptions = {
+                title: 'Prompt',
+                buttonLabelOk: 'OK',
+                buttonLabelCancel: 'Cancel'
+            };
+            if (options) {
+                $.extend(dialogOptions, options);
+            }
+            var inputId = 'dialog2-prompt-input';
+            var content = $('<form/>').addClass('form-stacked')
+                .append($('<label/>').attr('for', inputId).html(message))
+                .append($('<input/>').addClass('span6').attr({id: inputId, type: 'text'}).val(defaultValue));
+            $.dialog2.open(dialogOptions.title, content, [
+                {
+                    label: dialogOptions.buttonLabelCancel,
+                    classes: 'danger close-dialog',
+                    callback: callbackCancel
+                },
+                {
+                    label: dialogOptions.buttonLabelOk,
+                    classes: 'primary close-dialog',
+                    callback: function() { callbackOk($('#' + inputId).val()); }
+                }
+            ]);
+        },
+
+        open: function(title, content, buttons) {
+            var dialog = $('<div/>');
+            if (typeof content == 'object') {
+                dialog.append(content);
+            } else {
+                dialog.append($('<p/>').html(content));
+            }
+            var actions = $('<div/>').addClass('actions');
+            for (var i in buttons) {
+                var button = buttons[i];
+                actions.append($('<button/>').addClass(button.classes).html(button.label).click(button.callback));
+            }
+            dialog.append(actions).dialog2({
+                title: title,
+                showCloseHandle: false,
+                closeOnEscape: true,
+                closeOnOverlayClick: false
+            });
+        }
+    };
 })(jQuery);


### PR DESCRIPTION
I have created replacements for alert(), confirm() and prompt() in dialog2, inspired by [jqDialog](https://github.com/knadh/jqdialog).
