### PR TITLE
some nifty improvements

### DIFF
--- a/lib/jquery.dialog2.js
+++ b/lib/jquery.dialog2.js
@@ -1,106 +1,106 @@
 /*
  * Dialog2: Yet another dialog plugin for jQuery.
- * 
- * This time based on bootstrap styles with some nice ajax control features, 
+ *
+ * This time based on bootstrap styles with some nice ajax control features,
  * zero dependencies to jQuery.UI and basic options to control it.
- * 
- * Licensed under the MIT license 
- * http://www.opensource.org/licenses/mit-license.php 
- * 
+ *
+ * Licensed under the MIT license
+ * http://www.opensource.org/licenses/mit-license.php
+ *
  * @version: 1.1.0 (15/09/2011)
- * 
- * @requires jQuery >= 1.4 
- * 
- * @requires jQuery.form plugin (http://jquery.malsup.com/form/) >= 2.8 for ajax form submit 
+ *
+ * @requires jQuery >= 1.4
+ *
+ * @requires jQuery.form plugin (http://jquery.malsup.com/form/) >= 2.8 for ajax form submit
  * @requires jQuery.controls plugin (https://github.com/Nikku/jquery-controls) >= 0.9 for ajax link binding support
- * 
+ *
  * @requires bootstrap styles (twitter.github.com/bootstrap) to look nice
- * 
+ *
  * @author nico.rehwaldt
  */
 (function($) {
-    
+
     /**
      * Returns true if value is a boolean
      */
     function __boolean(value) {
         return typeof value == "boolean";
     };
-    
+
     /**
-     * Ajaxifies the dialogs contents, 
+     * Ajaxifies the dialogs contents,
      * creating ajax forms and ajax links on .ajax annotated elements
-     * 
+     *
      * @param dialog to be ajaxified
      */
     function __ajaxify(dialog) {
         dialog.find("a.ajax").click(function(event) {
             var url = $(this).attr("href");
-            
+
             $(dialog).dialog2("load", url);
             event.preventDefault();
         }).removeClass("ajax");
-        
-        // Make submitable for an ajax form 
+
+        // Make submitable for an ajax form
         // if the jquery.form plugin is provided
         if ($.fn.ajaxForm) {
             $("form.ajax", dialog).ajaxForm({
                 target: dialog,
                 success: $.proxy(__ajaxCompleteTrigger, dialog),
-                beforeSubmit: $.proxy(__ajaxStartTrigger, dialog), 
+                beforeSubmit: $.proxy(__ajaxStartTrigger, dialog),
                 error: function() {
                     throw new Error("[jquery.dialog2] form submit failed: " + $.makeArray(arguments));
                 }
             });
         }
-        
-        // Add buttons to dialog for all buttons found within 
+
+        // Add buttons to dialog for all buttons found within
         // a .actions area inside the dialog
         var actions = $(".actions", dialog).hide();
         var buttons = actions.find("input[type=submit], input[type=button], input[type=reset], button, .btn");
-        
+
         // Add buttons in reverse order, as they will appear in the
         // desired order on the dialog then
         buttons.each(function() {
             var button = $(this);
             var name = button.is("input") ? button.val() || button.attr("type") : button.text();
-            
+
             dialog.dialog2("addButton", name, {
                 primary: button.is("input[type=submit]"),
-                type: button.attr("class"), 
+                type: button.attr("class"),
                 click: function(event) {
                     // simulate click on the original button
                     // to not destroy any event handlers
                     button.click();
-                    
+
                     if (button.is(".close-dialog")) {
                         $(dialog).dialog2("close");
                     }
                 }
             });
         });
-        
-        
+
+
         // set title if content contains a h1 element
         var titleElement = dialog.find("h1").hide();
         if (titleElement.length > 0) {
             dialog.dialog2("options", {title: titleElement.text()});
         }
-        
+
         __focus(dialog);
     };
-    
+
     /**
      * Callback passed to load / form submit actions as a complete trigger
      */
     function __ajaxCompleteTrigger() {
         $(this).trigger("dialog2.ajax-complete");
     };
-    
+
     function __ajaxStartTrigger() {
         $(this).trigger("dialog2.ajax-start");
     };
-    
+
     /**
      * Put focus on the dialog
      */
@@ -110,7 +110,7 @@
                               .filter(function() {
                                   return $(this).parents(".actions").length == 0;
                               }).eq(0);
-        
+
         // Which might be a button, too
         if (!focusable.length) {
             focusable = dialog.parent().find(".modal-footer").find("input[type=submit], input[type=button], .btn, button");
@@ -118,14 +118,14 @@
                 focusable = focusable.eq(0);
             }
         }
-        
+
         focusable.focus();
     };
-    
+
     function __getOverlay(dialog) {
         return dialog.parent().prev(".modal-backdrop");
     }
-    
+
     /**
      * Cached functions (to be memorized for some reason)
      */
@@ -134,18 +134,18 @@
         __getOverlay(dialog).remove();
         dialog.remove();
     };
-    
-    var __DIALOG_HTML = "<div class='modal'>" + 
+
+    var __DIALOG_HTML = "<div class='modal'>" +
         "<div class='modal-header'>" +
-        "<h3></h3><span class='loader'></span>" + 
-        "<a href='#' class='close'></a>" + 
-        "</div>" + 
-        "<div class='modal-body'>" + 
-        "</div>" + 
-        "<div class='modal-footer'>" + 
-        "</div>" + 
+        "<h3></h3><span class='loader'></span>" +
+        "<a href='#' class='close'></a>" +
+        "</div>" +
+        "<div class='modal-body'>" +
+        "</div>" +
+        "<div class='modal-footer'>" +
+        "</div>" +
         "</div>";
-    
+
     /**
      * Public API methods exposed by the dialog2 plugin
      */
@@ -153,38 +153,38 @@
         close: function() {
             var dialog = $(this);
             __getOverlay(dialog).hide();
-            
+
             dialog
                 .parent().hide().end()
                 .trigger("dialog2.closed")
                 .removeClass("opened");
-        }, 
+        },
         open: function() {
             var dialog = $(this);
-            
+
             if (!dialog.is(".opened")) {
                 __getOverlay(dialog).show();
-                
+
                 dialog
                     .trigger("dialog2.before-open")
                     .addClass("opened")
                     .parent().show().end()
                     .trigger("dialog2.opened");
-                    
+
                 __focus(dialog);
             }
-        }, 
-        addButton: function(name, options) {          
+        },
+        addButton: function(name, options) {
             addDialogButton(this, name, options);
-        }, 
+        },
         removeButton: function(name) {
             var footer = $(this).siblings(".modal-footer");
-                
+
             footer
                 .find("a.btn")
                 .filter(function(i, e) {return $(e).text() == name;})
                 .remove();
-        }, 
+        },
         load: function(url) {
             $(this).trigger("dialog2.ajax-start")
                    .load(url, $.proxy(__ajaxCompleteTrigger, this));
@@ -192,19 +192,19 @@
         options: function(options) {
             var self = $(this);
             var handle = self.parent();
-            
+
             if (options.title) {
                 $(".modal-header h3", handle).text(options.title);
             }
-            
+
             if (options.buttons) {
                 $(".modal-footer", handle).empty();
-                
+
                 $.each(options.buttons, function(name, value) {
                     addDialogButton(self, name, value);
                 });
             }
-            
+
             if (__boolean(options.closeOnOverlayClick)) {
                 var overlay = __getOverlay(self);
                 overlay.unbind("click");
@@ -217,39 +217,39 @@
                     });
                 }
             }
-            
+
             if (__boolean(options.showCloseHandle)) {
                 var closeHandleMode = options.showCloseHandle ? "show" : "hide";
                 $(".modal-header .close", handle)[closeHandleMode]();
             }
-            
+
             if (__boolean(options.removeOnClose)) {
                 self.unbind("dialog2.closed", __removeDialog);
-                
+
                 if (options.removeOnClose) {
                     self.bind("dialog2.closed", __removeDialog);
                 }
             }
-            
+
             if (options.autoOpen === true) {
                 self.dialog2("open");
             }
-            
+
             if (options.content) {
                 self.empty().dialog2("load", options.content);
             }
-            
+
             return this;
         }
     };
-    
+
     /**************************************************************************
      * Private utility methods                                                *
      **************************************************************************/
-    
+
     function addDialogButton(dialog, name, options) {
         var callback = $.isFunction(options) ? options : options.click;
-        
+
         var footer = $(dialog).siblings(".modal-footer");
 
         var button = $("<a href='#' class='btn'></a>")
@@ -258,33 +258,33 @@
                                 callback.apply(dialog, [event]);
                                 event.preventDefault();
                             });
-        
+
         // legacy
         if (options.primary) {
             button.addClass("primary");
         }
-        
+
         if (options.type) {
             button.addClass(options.type);
         }
-        
+
         footer.append(button);
     };
-    
+
     /**
      * Core function for creating new dialogs.
      * Transforms a jQuery selection into dialog content, following these rules:
-     * 
+     *
      * // selector is a dialog? Does essentially nothing
      * $(".selector").dialog2();
-     * 
+     *
      * // .selector known?
      * // creates a dialog wrapped around .selector
      * $(".selector").dialog2();
-     * 
+     *
      * // creates a dialog wrapped around .selector with id foo
      * $(".selector").dialog2({id: "foo"});
-     * 
+     *
      * // .unknown-selector not known? Creates a new dialog with id foo and no content
      * $(".unknown-selector").dialog2({id: "foo"});
      */
@@ -292,30 +292,32 @@
 
         var selection = $(element);
         var dialog;
-        
+
         var created = false;
-        
+
         if (!selection.is(".modal-body")) {
             var overlay = $('<div class="modal-backdrop"></div>').appendTo("body").hide();
             var handle = $(__DIALOG_HTML).appendTo("body");
-            
+
+            $(handle).addClass(options.class);
+
             $(".modal-header a.close", handle)
                 .text(unescape("%D7"))
                 .click(function(event) {
                     event.preventDefault();
-                    
+
                     $(this)
                         .parents(".modal")
                         .find(".modal-body")
                             .dialog2("close");
                 });
-            
+
             dialog = $(".modal-body", handle);
-            
+
             // Create dialog body from current jquery selection
-            // If specified body is a div element and only one element is 
+            // If specified body is a div element and only one element is
             // specified, make it the new modal dialog body
-            // Allows us to do something like this 
+            // Allows us to do something like this
             // $('<div id="foo"></div>').dialog2(); $("#foo").dialog2("open");
             if (selection.is("div") && selection.length == 1) {
                 dialog.replaceWith(selection);
@@ -326,48 +328,48 @@
             else {
                 dialog.append(selection);
             }
-            
+
             dialog.bind("dialog2.ajax-start", function() {
-                $(this).dialog2("options", {buttons: localizedCancelButton()})
+                $(this).dialog2("options", {buttons: options.autoAddCancelButton ? localizedCancelButton() : [] })
                        .parent().addClass("loading");
             });
-            
+
             dialog.bind("dialog2.ajax-complete", function() {
                 var self = $(this);
-                
+
                 self.parent().removeClass("loading");
                 __ajaxify(self);
             });
-            
+
             if (options.id) {
                 dialog.attr("id", options.id);
             }
-            
+
             // we just created this one
             created = true;
         } else {
             dialog = selection;
         }
-        
+
         // Apply options to make title and stuff shine
         dialog.dialog2("options", options);
-        
+
         // We will ajaxify its contents when its new
         // aka apply ajax styles in case this is a inpage dialog
         if (created) {
             __ajaxify(dialog);
         }
-                
+
         return dialog;
     };
-    
+
     /**
      * Localizes a given key using the selected language
      */
     function localize(key) {
         return lang[key];
     };
-    
+
     /**
      * Returns a localized cancel button
      */
@@ -376,30 +378,30 @@
         option[localize("cancel")] = function() {
             $(this).dialog2("close");
         };
-        
+
         return option;
     };
-    
+
     $.extend($.fn, {
-        
+
         /**
          * options = {
-         *   title: "Some title", 
-         *   id: "my-id", 
+         *   title: "Some title",
+         *   id: "my-id",
          *   buttons: {
-         *     "Name": Object || function   
+         *     "Name": Object || function
          *   }
          * };
-         * 
+         *
          * $(".selector").dialog2(options);
-         * 
-         * or 
-         * 
+         *
+         * or
+         *
          * $(".selector").dialog2("method", arguments);
          */
         dialog2: function() {
             var args = $.makeArray(arguments);
-            
+
             var arg0 = args.shift();
             if (typeof arg0 == "string") {
                 var method = dialog2[arg0];
@@ -414,52 +416,53 @@
                 if ($.isPlainObject(arg0)) {
                     options = $.extend(true, options, arg0);
                 }
-                
+
                 return checkCreateDialog(this, options);
             }
         }
     });
-    
+
     $.fn.dialog2.defaults = {
-        autoOpen: true, 
-        closeOnOverlayClick: true, 
-        removeOnClose: true, 
-        showCloseHandle: true
+        autoOpen: true,
+        closeOnOverlayClick: true,
+        removeOnClose: true,
+        showCloseHandle: true,
+        autoAddCancelButton: true,
     };
-    
+
     $.fn.dialog2.localization = {
         "de": {
             cancel: "Abbrechen"
-        },         
+        },
         "en": {
             cancel: "Cancel"
         }
     };
-    
+
     var lang = $.fn.dialog2.localization["en"];
-    
+
     $.fn.dialog2.localization.setDefault = function(key) {
         var localization = $.fn.dialog2.localization[key];
-        
+
         if (localization == null) {
             throw new Error("No localizaton for language " + key);
         } else {
             lang = localization;
         }
     };
-    
+
     /**
      * Register opening of a dialog on annotated links
-     * (works only if jquery.controls plugin is installed). 
+     * (works only if jquery.controls plugin is installed).
      */
     if ($.fn.controls && $.fn.controls.bindings) {
         $.extend($.fn.controls.bindings, {
             "a.open-dialog": function() {
                 var a = $(this).removeClass("open-dialog");
-                
+
                 var id = a.attr("rel");
                 var content = a.attr("href");
-                
+
                 var options = {
                     modal: true
                 };
@@ -480,16 +483,20 @@
                 if (a.attr("title")) {
                     options.title = a.attr("title");
                 }
-                
+
+                if (a.attr("data-dialog-class")) {
+                    options.class = a.attr("data-dialog-class");
+                }
+
                 $.each($.fn.dialog2.defaults, function(key, value) {
                     if (a.attr(key)) {
                         options[key] = a.attr(key) == "true";
                     }
                 });
-                
+
                 if (content && content != "#") {
                     options.content = content;
-                    
+
                     a.click(function(event) {
                         event.preventDefault();
                         $(element || "<div></div>").dialog2(options);
@@ -497,12 +504,12 @@
                 } else {
                     options.removeOnClose = false;
                     options.autoOpen = false;
-                    
+
                     element = element || "<div></div>";
-                    
+
                     // Pre initialize dialog
                     $(element).dialog2(options);
-                    
+
                     a.attr("href", "#")
                      .click(function(event) {
                          event.preventDefault();
@@ -512,7 +519,7 @@
             }
         });
     };
-    
+
     $.dialog2 = {
         alert: function(message, callback, options) {
             var dialogOptions = {

--- a/lib/jquery.dialog2.js
+++ b/lib/jquery.dialog2.js
@@ -66,7 +66,7 @@
             var name = button.is("input") ? button.val() || button.attr("type") : button.text();
 
             dialog.dialog2("addButton", name, {
-                primary: button.is("input[type=submit]"),
+                primary: button.is("input[type=submit] .primary"),
                 type: button.attr("class"),
                 click: function(event) {
                     // simulate click on the original button


### PR DESCRIPTION
Hi,

I've seen we can add a id but it only applies to .modal-body DOM element. I often use ajax loaded forms and when modal is created from scratch I can't set a style (width for example).

So I have added data-dialog-class markup which add a class to .modal DOM element.

Another thing :
I have Added default option : autoAddCancelButton, true by default for backward compatibility. When setted to false cancel button is not added into ajax loaded modal.
