### PR TITLE
Fixes modal close button positioning issue

### DIFF
--- a/css/jquery-dialog2/jquery.dialog2.css
+++ b/css/jquery-dialog2/jquery.dialog2.css
@@ -4,10 +4,6 @@
      margin: 0 0 0 -280px;
 }
 
-.modal .modal-header h3 {
-    display: inline-block;
-}
-
 .modal.loading .modal-header .loader {
     height: 36px;
     width: 16px;

--- a/lib/jquery.dialog2.js
+++ b/lib/jquery.dialog2.js
@@ -25,8 +25,8 @@
      */
     var __DIALOG_HTML = "<div class='modal'>" + 
         "<div class='modal-header'>" +
+		"<a href='#' class='close'></a>" +
         "<h3></h3><span class='loader'></span>" + 
-        "<a href='#' class='close'></a>" + 
         "</div>" + 
         "<div class='modal-body'>" + 
         "</div>" + 


### PR DESCRIPTION
When a modal has a lengthy title, or the modal div is narrow, the `h3` title can fill the entire horizontal width of the modal. When this happens, the `x` close button is bumped down the screen incorrectly. 

This fork moves the close link html above the `h3` tag, as is specified by the twitter bootstrap documentation. It also removes additional css that was added at some point which causes the `h3` title to bump down the screen as well.
