### PR TITLE
Don't set text on input for prompt()

### DIFF
--- a/lib/jquery.dialog2.helpers.js
+++ b/lib/jquery.dialog2.helpers.js
@@ -114,7 +114,6 @@
             var inputId = 'dialog2.helpers.prompt.input.id';
             var input = $("<input type='text' class='span6' />")
                                 .attr("id", inputId)
-                                .text(message)
                                 .val(options.defaultValue || "");
                                 
             var html = $("<form class='form-stacked'></form>");


### PR DESCRIPTION
Fixes a javascript error in IE8 when using prompt()
