### PR TITLE
Support to reload

### DIFF
--- a/lib/jquery.dialog2.js
+++ b/lib/jquery.dialog2.js
@@ -802,65 +802,82 @@
      * (works only if jquery.controls plugin is installed). 
      */
     if ($.fn.controls && $.fn.controls.bindings) {
+        function register_dialog2(a) {
+            a.removeClass("open-dialog");
+            a.addClass("dialog-registered");
+
+            var id = a.attr("rel");
+            var content = a.attr("href");
+
+            var options = {
+                modal: true
+            };
+
+            var element;
+
+            if (id) {
+                var e = $("#" + id);
+                if (e.length) element = e;
+            }
+
+            if (!element) {
+                if (id) {
+                    options.id = id;
+                }
+            }
+
+            if (a.attr("data-dialog-class")) {
+                options.modalClass = a.attr("data-dialog-class");
+            }
+
+            if (a.attr("title")) {
+                options.title = a.attr("title");
+            }
+
+            $.each($.fn.dialog2.defaults, function(key, value) {
+                if (a.attr(key)) {
+                    options[key] = a.attr(key) == "true";
+                }
+            });
+
+            if (content && content != "#") {
+                options.content = content;
+
+                a.bind('click.jquery-dialog2', function(event) {
+                    event.preventDefault();
+                    $(element || "<div></div>").dialog2(options);
+                });
+            } else {
+                options.removeOnClose = false;
+                options.autoOpen = false;
+
+                element = element || "<div></div>";
+
+                // Pre initialize dialog
+                $(element).dialog2(options);
+
+                a.attr("href", "#")
+                    .bind('click.jquery-dialog2', function(event) {
+                        event.preventDefault();
+                        $(element).dialog2("open");
+                    });
+            }
+        };
+
         $.extend($.fn.controls.bindings, {
             "a.open-dialog": function() {
-                var a = $(this).removeClass("open-dialog");
-                
-                var id = a.attr("rel");
-                var content = a.attr("href");
-                
-                var options = {
-                    modal: true
-                };
+                register_dialog2($(this))
+            }
+        });
 
-                var element;
-
-                if (id) {
-                    var e = $("#" + id);
-                    if (e.length) element = e;
-                }
-
-                if (!element) {
-                    if (id) {
-                        options.id = id;
-                    }
-                }
-                
-                if (a.attr("data-dialog-class")) {
-                    options.modalClass = a.attr("data-dialog-class");
-                }
-                
-                if (a.attr("title")) {
-                    options.title = a.attr("title");
-                }
-                
-                $.each($.fn.dialog2.defaults, function(key, value) {
-                    if (a.attr(key)) {
-                        options[key] = a.attr(key) == "true";
-                    }
-                });
-                
-                if (content && content != "#") {
-                    options.content = content;
-                    
-                    a.click(function(event) {
-                        event.preventDefault();
-                        $(element || "<div></div>").dialog2(options);
-                    });
-                } else {
-                    options.removeOnClose = false;
-                    options.autoOpen = false;
-                    
-                    element = element || "<div></div>";
-                    
-                    // Pre initialize dialog
-                    $(element).dialog2(options);
-                    
-                    a.attr("href", "#")
-                     .click(function(event) {
-                         event.preventDefault();
-                         $(element).dialog2("open");
-                     });
+        $.fn.extend({
+            reload_dialog2: function(){
+                e = this.find('.dialog-registered');
+                if(e.length >= 1) {
+                    e.unbind('click.jquery-dialog2');
+                    e.removeClass('dialog-registered');
+                    e.addClass('open-dialog');
+                    register_dialog2(e);
                 }
             }
         });


### PR DESCRIPTION
When using dynamic links jquery.dialog2 not works https://github.com/nikku/jquery-bootstrap-scripting/issues/38 - with this change is possible reload only doing a simple call, for example using the document: 

``` javascript
$(document).reload_dialog2()
```
